### PR TITLE
Disable caching on worker nodes in the same application

### DIFF
--- a/login/login-spark.yaml
+++ b/login/login-spark.yaml
@@ -20,6 +20,7 @@
           content: |
               spark.driver.port=9000
               spark.blockManager.port=9020
+              spark.files.useFetchCache=false
               spark.authenticate=true
               spark.authenticate.secret={{ lookup('password', '/dev/null length=64') }}
 


### PR DESCRIPTION
This option is set to true by default, which increases performance when working on a local standalone cluster, but is incompatible with worker nodes coming from different clusters, so it should be disabled by default in VC3 spark clusters.