### PR TITLE
Build python for pyspark-xrootd requirement

### DIFF
--- a/login/login-spark.yaml
+++ b/login/login-spark.yaml
@@ -7,7 +7,7 @@
   become_user: root
 
   vars:
-    builder_headnode_options: '--require spark-xrootd'
+    builder_headnode_options: '--no-sys python --require spark-xrootd'
 
   tasks:
     - import_tasks: components/host.yaml
@@ -54,5 +54,5 @@
           mode: 0755
 
     - name: Start spark
-      shell: nohup /bin/vc3-builder --var TERM=linux --var "SPARK_MASTER_HOST={{ headnode_ip }}" --install /opt/vc3/root --distfiles /opt/vc3/distfiles --home /opt/vc3/home --require spark --no-sys python -- '$VC3_ROOT_SPARK/sbin/start-master.sh --properties-file /etc/vc3-spark.conf' &
+      shell: nohup /bin/vc3-builder --var TERM=linux --var "SPARK_MASTER_HOST={{ headnode_ip }}" --install /opt/vc3/root --distfiles /opt/vc3/distfiles --home /opt/vc3/home --require spark -- '$VC3_ROOT_SPARK/sbin/start-master.sh --properties-file /etc/vc3-spark.conf' &
 


### PR DESCRIPTION
pyspark-xrootd doesn't seem to always like the system-build python, this works around that issue:

```led to build for x86_64/redhat7", "Last lines of log file:", "    creating build/temp.linux-x86_64-2.7", "    gcc -fno-strict-aliasing -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -DNDEBUG -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/usr/include/python2.7 -c _posixsubprocess.c -o build/temp.linux-x86_64-2.7/_posixsubprocess.o", "    _posixsubprocess.c:16:20: fatal error: Python.h: No such file or directory", "     #include \"Python.h\"", "                        ^", "    compilation terminated.", "    error: command 'gcc' failed with exit status 1", "    ", "    ----------------------------------------", "Command \"/bin/python -u -c \"import setuptools, tokenize;__file__='/opt/vc3/root/tmp/pip-install-I2n3S2/subprocess32/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\\r\\n', '\\n');f.close();exec(compile(code, __file__, 'exec'))\" install --record /opt/vc3/root/tmp/pip-record-RlKQYt/install-record.txt --single-version-externally-managed --compile --user --prefix=\" failed with error code 1 in /opt/vc3/root/tmp/pip-install-I2n3S2/subprocess32/", "Cleaning payload with pid: 15783"]}```